### PR TITLE
feat: implement `wait()` and `kill()` properly

### DIFF
--- a/containerd-shim-aspdotnet-v1/src/main.rs
+++ b/containerd-shim-aspdotnet-v1/src/main.rs
@@ -83,11 +83,11 @@ pub fn prepare_module(
 
     let ip_address = "0.0.0.0:80";
     let stdlistener = std::net::TcpListener::bind(ip_address)
-        .with_context(|| format!("failed to bind to address '0.0.0.0:80'"))?;
+        .with_context(|| "failed to bind to address '0.0.0.0:80'".to_string())?;
 
     let _ = stdlistener.set_nonblocking(true)?;
     let tcplisten = TcpListener::from_std(stdlistener);
-    wasi_builder = wasi_builder.preopened_socket(3 as _, tcplisten)?;
+    wasi_builder = wasi_builder.preopened_socket(3_u32, tcplisten)?;
 
     wasi_builder = wasi_builder.env("ASPNETCORE_URLS", "http://0.0.0.0:8080")?;
 
@@ -210,7 +210,7 @@ impl Instance for Wasi {
                 info!("starting wasi instance");
 
                 let (lock, cvar) = &*exit_code;
-                let _ret = match f.call(&mut store, &mut vec![], &mut vec![]) {
+                let _ret = match f.call(&mut store, &mut [], &mut []) {
                     Ok(_) => {
                         info!("exit code: {}", 0);
                         let mut ec = lock.lock().unwrap();

--- a/containerd-shim-spin-v1/src/main.rs
+++ b/containerd-shim-spin-v1/src/main.rs
@@ -16,7 +16,7 @@ use std::fs::OpenOptions;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::mpsc::channel;
-use std::sync::mpsc::{Receiver, Sender};
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use tokio::runtime::Runtime;

--- a/containerd-shim-spin-v1/src/main.rs
+++ b/containerd-shim-spin-v1/src/main.rs
@@ -122,7 +122,6 @@ impl Instance for Wasi {
     type E = spin_engine::Engine;
     fn new(id: String, cfg: Option<&InstanceConfig<Self::E>>) -> Self {
         let cfg = cfg.unwrap();
-        let (tx, rx) = std::sync::mpsc::channel::<()>();
         Wasi {
             exit_code: Arc::new((Mutex::new(None), Condvar::new())),
             engine: cfg.get_engine(),


### PR DESCRIPTION
This PR implements the `wait()` and `kill()` instance functions in Spin Shim. It fixes #10 issue.

Signed-off-by: jiaxiao zhou <jiazho@microsoft.com>