### PR TITLE
Added handling of the case where `containerd` gives us empty IO paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,8 +2284,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "0.1.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-log-pipes#e2fb68faf7b0b88224d363afa615d7c102c9f8a4"
+version = "0.2.0"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
 dependencies = [
  "anyhow",
  "redis",
@@ -3254,8 +3254,8 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-config"
-version = "0.1.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-log-pipes#e2fb68faf7b0b88224d363afa615d7c102c9f8a4"
+version = "0.2.0"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
 dependencies = [
  "anyhow",
  "serde",
@@ -3265,8 +3265,8 @@ dependencies = [
 
 [[package]]
 name = "spin-engine"
-version = "0.1.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-log-pipes#e2fb68faf7b0b88224d363afa615d7c102c9f8a4"
+version = "0.2.0"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",
@@ -3287,8 +3287,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http-engine"
-version = "0.1.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-log-pipes#e2fb68faf7b0b88224d363afa615d7c102c9f8a4"
+version = "0.2.0"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3324,8 +3324,8 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "0.1.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-log-pipes#e2fb68faf7b0b88224d363afa615d7c102c9f8a4"
+version = "0.2.0"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3356,8 +3356,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "0.1.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-log-pipes#e2fb68faf7b0b88224d363afa615d7c102c9f8a4"
+version = "0.2.0"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3368,8 +3368,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "0.1.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-log-pipes#e2fb68faf7b0b88224d363afa615d7c102c9f8a4"
+version = "0.2.0"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4277,8 +4277,8 @@ dependencies = [
 
 [[package]]
 name = "wasi-outbound-http"
-version = "0.1.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-log-pipes#e2fb68faf7b0b88224d363afa615d7c102c9f8a4"
+version = "0.2.0"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tar",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "toml",
  "tracing",
  "tracing-futures",
@@ -517,7 +517,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.2",
 ]
 
 [[package]]
@@ -1044,9 +1044,9 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "ed25519"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d916019f70ae3a1faa1195685e290287f39207d38e6dfee727197cffcc002214"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "signature",
 ]
@@ -1424,7 +1424,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.2",
  "tracing",
 ]
 
@@ -1531,7 +1531,7 @@ checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "itoa 1.0.1",
+ "itoa 1.0.2",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1596,7 +1596,7 @@ dependencies = [
  "http 0.2.7",
  "hyper",
  "log",
- "rustls 0.20.4",
+ "rustls 0.20.5",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.4",
@@ -1757,9 +1757,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jobserver"
@@ -2221,9 +2221,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openid"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30a9456b3484c408d9708b6f65b2bd834fdf22b73567775e1ca6de5524dd19"
+checksum = "874cd75d55a8371aa3abae9d6dc69e1f8c113e7169a7ddfe9d397c042edea732"
 dependencies = [
  "base64 0.13.0",
  "biscuit",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "outbound-redis"
 version = "0.2.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#f434f4b35541f417cbd7c043d9e3d3160e2b8dd1"
 dependencies = [
  "anyhow",
  "redis",
@@ -2616,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -2628,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2654,7 +2654,7 @@ dependencies = [
  "pin-project-lite",
  "sha1",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "url 2.2.2",
 ]
 
@@ -2761,7 +2761,7 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "rustls 0.20.4",
+ "rustls 0.20.5",
  "rustls-pemfile 0.3.0",
  "serde",
  "serde_json",
@@ -2769,7 +2769,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.23.4",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2839,7 +2839,7 @@ dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "libc",
  "linux-raw-sys",
  "once_cell",
@@ -2861,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "a024a432ae760ab3bff924ad91ce1cfa52cb57ed16e1ef32d0d249cfee1a6c13"
 dependencies = [
  "log",
  "ring",
@@ -2903,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "safemem"
@@ -3043,7 +3043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "indexmap",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -3064,7 +3064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -3152,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3255,7 +3255,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "spin-config"
 version = "0.2.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#f434f4b35541f417cbd7c043d9e3d3160e2b8dd1"
 dependencies = [
  "anyhow",
  "serde",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "spin-engine"
 version = "0.2.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#f434f4b35541f417cbd7c043d9e3d3160e2b8dd1"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "spin-http-engine"
 version = "0.2.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#f434f4b35541f417cbd7c043d9e3d3160e2b8dd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3325,7 +3325,7 @@ dependencies = [
 [[package]]
 name = "spin-loader"
 version = "0.2.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#f434f4b35541f417cbd7c043d9e3d3160e2b8dd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3346,7 +3346,7 @@ dependencies = [
  "spin-manifest",
  "tempfile",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "toml",
  "tracing",
  "tracing-futures",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "spin-manifest"
 version = "0.2.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#f434f4b35541f417cbd7c043d9e3d3160e2b8dd1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "spin-trigger"
 version = "0.2.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#f434f4b35541f417cbd7c043d9e3d3160e2b8dd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3406,9 +3406,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
+checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3536,7 +3536,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "libc",
  "num_threads",
  "quickcheck",
@@ -3650,7 +3650,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.4",
+ "rustls 0.20.5",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -3696,9 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -3710,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -4172,7 +4172,7 @@ dependencies = [
  "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower-service",
  "tracing",
 ]
@@ -4278,7 +4278,7 @@ dependencies = [
 [[package]]
 name = "wasi-outbound-http"
 version = "0.2.0"
-source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#d9397ea9eb80ca383a4ef8b92cbbe08c983c2846"
+source = "git+https://github.com/danbugs/spin?branch=danbugs/custom-logging-pipes#f434f4b35541f417cbd7c043d9e3d3160e2b8dd1"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -10,10 +10,10 @@ chrono = "0.4.19"
 containerd-shim = "0.3.0"
 containerd-shim-wasmtime-v1 = { git = "https://github.com/Mossaka/runwasi", branch = "jiazho/precompile" }
 log = "0.4"
-spin-trigger = { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-log-pipes" } 
-spin-engine = { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-log-pipes" }
-spin-http-engine =  { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-log-pipes" }
-spin-loader =  { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-log-pipes" }
-spin-manifest = { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-log-pipes" }
+spin-trigger = { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-logging-pipes" } 
+spin-engine = { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-logging-pipes" }
+spin-http-engine =  { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-logging-pipes" }
+spin-loader =  { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-logging-pipes" }
+spin-manifest = { git = "https://github.com/danbugs/spin", branch = "danbugs/custom-logging-pipes" }
 tokio = { version = "1.11", features = [ "rt" ] }
 wasmtime = "^0.34"

--- a/containerd-shim-spin-v1/src/main.rs
+++ b/containerd-shim-spin-v1/src/main.rs
@@ -65,6 +65,7 @@ impl Wasi {
                     OpenOptions::new()
                         .read(true)
                         .write(true)
+                        .create(true)
                         .open(stdin_pipe_path.clone())
                         .unwrap(),
                     stdin_pipe_path.clone()),
@@ -72,6 +73,7 @@ impl Wasi {
                     OpenOptions::new()
                         .read(true)
                         .write(true)
+                        .create(true)
                         .open(stdout_pipe_path.clone())
                         .unwrap(),
                     stdout_pipe_path.clone()),
@@ -79,6 +81,7 @@ impl Wasi {
                     OpenOptions::new()
                         .read(true)
                         .write(true)
+                        .create(true)
                         .open(stderr_pipe_path.clone())
                         .unwrap(),
                         stderr_pipe_path.clone()


### PR DESCRIPTION
This addresses issue #16 